### PR TITLE
Replace all occurrences of gender "not_set"

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1080,7 +1080,7 @@ class Empire {
         // Ruler gender, spawn_as_fallen, ignore_portrait_duplication and spawn_enabled do not use quote despite being strings (??)
         string = string.replace(/gender="female"/g, 'gender=female');
         string = string.replace(/gender="male"/g, 'gender=male');
-        string = string.replace(/gender="not_set"/, 'gender=not_set');
+        string = string.replace(/gender="not_set"/g, 'gender=not_set');
         string = string.replace(/spawn_as_fallen="yes"/, 'spawn_as_fallen=yes');
         string = string.replace(/spawn_as_fallen="no"/, 'spawn_as_fallen=no');
         string = string.replace(/ignore_portrait_duplication="no"/, 'ignore_portrait_duplication=no');


### PR DESCRIPTION
Specifically, secondary species can have an unset gender. This replaces all occurrences like for `male` and `female`.

![image](https://user-images.githubusercontent.com/2653277/216858013-1c9a4f43-271d-4acf-8fb1-ef3c21a632f4.png)
